### PR TITLE
feat: direct send of NFT from lender to renter

### DIFF
--- a/rental-escrow-smart-contract/src/CollateralRegistry.sol
+++ b/rental-escrow-smart-contract/src/CollateralRegistry.sol
@@ -319,9 +319,10 @@ contract CollateralRegistry is ERC721Holder, ERC1155Holder, ReentrancyGuard {
     }
 
     /**
-     * @notice Lender calls this to release the NFT to the renter.
-     * @dev Only available for collateral rentals.
-     * @dev Uses TimeConverter to convert hours to seconds.
+     * @notice Lender calls this to directly transfer the NFT to the renter, bypassing escrow.
+     * @dev Only available for collateral rentals in READY_TO_RELEASE state.
+     * @dev This function allows lenders to transfer NFTs directly without depositing to escrow first.
+     * @param _rentalId The ID of the rental agreement
      */
     function releaseNFTToRenterFromLender(uint256 _rentalId) 
         external


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability for lenders to directly release NFTs to renters when a rental is ready to be activated. This streamlines the process for collateral-based rentals and ensures secure transfer of NFTs between parties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->